### PR TITLE
allow use ES7 syntax/features on mocha tests

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "npm run lint && npm run test && npm run compile",
     "lint": "eslint src",
-    "test": "nyc mocha --compilers js:babel-register --recursive",
+    "pretest": "npm run lint",
+    "test": "nyc mocha -r babel-polyfill --compilers js:babel-register --recursive",
     "compile": "babel src --out-dir dist",
     "prepublish": "npm run build"
   },
@@ -46,6 +47,7 @@
     "babel-eslint": "^6.1.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2016": "^6.22.0",
     "babel-preset-es2017": "^6.22.0",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -7,7 +7,7 @@
     "node": ">=5.11.0"
   },
   "scripts": {
-    "build": "npm run lint && npm run test && npm run compile",
+    "build": "npm run test && npm run compile",
     "lint": "eslint src",
     "pretest": "npm run lint",
     "test": "nyc mocha -r babel-polyfill --compilers js:babel-register --recursive",

--- a/generators/app/templates/src/hello-world/_index.js
+++ b/generators/app/templates/src/hello-world/_index.js
@@ -1,3 +1,9 @@
-export default function helloWorld() {
+export function helloWorld() {
   return 'Hello World';
 }
+
+export function helloWorldAsync() {
+  return Promise.resolve(`Async ${helloWorld()}`);
+}
+
+export default helloWorld;

--- a/generators/app/templates/test/hello-world/_index.test.js
+++ b/generators/app/templates/test/hello-world/_index.test.js
@@ -1,9 +1,12 @@
 import expect from 'expect.js';
-import helloWorld from '../../src/hello-world';
-
+import { helloWorld, helloWorldAsync } from '../../src/hello-world';
 
 describe('Hello World', () => {
   it('returns Hello World', () => {
     expect(helloWorld()).to.be('Hello World');
   });
+
+  it('returns async Hello world', async () => {
+    expect(await helloWorldAsync()).to.be('Async Hello World');
+  })
 });


### PR DESCRIPTION
## What this PR does?
Add support of ES7 features to mocha tests and closes #4 

## Before
Can't use async/await on mocha tests without fail

## After
Can use async/await

## Now to test

Install **yeoman** globally `npm install -g yo`

1. Clone this repository
2. make a local link `npm link`
3. create a new folder and inside run `$ yo`
4. Choose "Run a generator" option "Bix Node Module"
5. execute "npm test"
